### PR TITLE
ADD new functionality to have cloud-init fix a slow SSH connection

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ data "template_file" "create_userdata" {
 
   vars = {
     DISABLE_ROOT          = var.userdata_disable_root
+    FIX_SLOW_SSH_LOGIN    = var.userdata_fix_slow_ssh_login
     MANAGE_ETC_HOSTS      = var.userdata_manage_etc_hosts
     MANAGE_RESOLV_CONF    = var.userdata_manage_resolv_conf
     IMAGE_NAME            = var.userdata_image_name

--- a/userdata_template.d/userdata.tpl
+++ b/userdata_template.d/userdata.tpl
@@ -1,4 +1,10 @@
 #cloud-config
+%{ if FIX_SLOW_SSH_LOGIN == "true" ~}
+
+# Enable cloud-init modules
+cloud_config_modules:
+  - runcmd
+%{ endif ~}
 
 # set the /etc/hosts
 manage_etc_hosts: ${MANAGE_ETC_HOSTS}
@@ -29,6 +35,15 @@ users:
     ssh_authorized_keys:
     - ${SSH_PUBKEY}
 %{ endif ~}
+%{ endif ~}
+%{ if FIX_SLOW_SSH_LOGIN == "true" ~}
+
+runcmd:
+    - sed -i '/UseDNS/s/^.*$/UseDNS no/' /etc/ssh/sshd_config
+    - sed -i '/ChallengeResponseAuthentication/s/^.*$/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config
+    - sed -i '/KerberosAuthentication/s/^.*$/KerberosAuthentication no/' /etc/ssh/sshd_config
+    - sed -i '/GSSAPIAuthentication/s/^.*$/GSSAPIAuthentication no/' /etc/ssh/sshd_config
+    - systemctl restart sshd
 %{ endif ~}
 
 # eof

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,12 @@ variable "userdata_disable_root" {
   default     = "true"
 }
 
+variable "userdata_fix_slow_ssh_login" {
+  type        = string
+  description = "Fix the slow SSH login by disabling UseDNS, GSSAPIAuthentication and others of that kidney"
+  default     = "false"
+}
+
 variable "userdata_image_name" {
   type        = string
   description = "Name of the image used to create the instance(s)"


### PR DESCRIPTION
ADD new functionality to have cloud-init fix a slow SSH connection by disabling some stupid things like UseDNS, GSSAPIAuthentication, KerberosAuthentication or ChallengeResponseAuthentication